### PR TITLE
Add game/season stat tracking, TD crediting, and CLI stat menus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,12 @@ NCAA College Football season simulator written in Python. Simulates games play-b
 - Tests run against Python 3.10, 3.11, and 3.12
 
 ## Key Commands
-- **Run tests**: `python -m pytest tests/ -v`
-- **Run single test file**: `python -m pytest tests/test_game.py -v`
-- **Run simulation**: `python -m src.main`
-- **Run GUI**: `python gui.py`
+- **Run tests**: `python3.10 -m pytest tests/ -v`
+- **Run single test file**: `python3.10 -m pytest tests/test_game.py -v`
+- **Run simulation**: `python3.10 -m src.main`
+- **Run GUI**: `python3.10 gui.py`
+
+> **Note:** On this machine, use `python3.10` — it's the version with pytest installed. `python` is not aliased, and `python3` points to 3.13 which lacks project dependencies.
 
 ## Rules Reference
 Before modifying a mechanic, read its rules doc first:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# NCAA College Football Simulator
+
+A Python-based NCAA college football season simulator. Simulates games play-by-play, manages full seasons with conference scheduling, and runs an 8-team playoff bracket.
+
+## Requirements
+
+- Python 3.10+
+- numpy
+
+## Quick Start
+
+### CLI (Interactive)
+
+```bash
+python src/cli.py
+```
+
+Or via the module entry point:
+
+```bash
+python -m src.main
+```
+
+This launches an interactive, menu-driven interface that lets you:
+
+- **Start a new season** with all NCAA teams, auto-generated schedules, and conference play
+- **Advance week by week** — view the schedule, simulate games, and check results at your own pace
+- **View standings and Top 25** rankings at any point during the season
+- **Look up any team** by name to see their record and full starting lineup
+- **Simulate the rest of the regular season** in one step when you're ready to skip ahead
+- **Run the 8-team playoff** and crown a national champion
+
+### CLI Menu Flow
+
+```
+Main Menu → Start New Season → Weekly Menu (loop) → Post-Season Menu → Run Playoffs → Champion Screen
+```
+
+- **Weekly Menu**: View schedule, play the week, view results, standings, Top 25, team lookup, or sim the rest of the season
+- **Post-Season Menu**: View final standings, preview the playoff bracket, or run the playoffs
+- **Champion Screen**: View final standings, start a new season, or quit
+
+### Simulate a Full Season (Non-Interactive)
+
+From the main menu, select **Simulate Full Season** to auto-play the entire regular season and playoffs in one shot.
+
+### GUI
+
+A basic tkinter GUI is also available:
+
+```bash
+python gui.py
+```
+
+## Running Tests
+
+```bash
+python -m pytest tests/ -v
+```
+
+## Project Structure
+
+```
+src/            Core simulation logic
+  cli.py        Interactive CLI
+  main.py       Module entry point
+  game.py       Game engine
+  play.py       Play execution (run/pass)
+  season.py     Season and scheduling
+  playoffs.py   8-team playoff bracket
+  team.py       Team and roster management
+  player.py     Player generation and ratings
+  stats.py      Game statistics tracking
+  config/       Conference rules and scheduling configs
+utils/          Team data (cfb.json) and data loading
+tests/          Pytest test suite
+gui.py          Tkinter GUI
+```

--- a/src/cli.py
+++ b/src/cli.py
@@ -69,11 +69,13 @@ class CLI:
         print("  4. View Standings")
         print("  5. View Top 25")
         print("  6. Team Lookup")
-        print("  7. Sim Rest of Regular Season")
-        print("  8. Return to Main Menu")
+        print("  7. View Game Box Scores")
+        print("  8. View Season Leaders")
+        print("  9. Sim Rest of Regular Season")
+        print("  10. Return to Main Menu")
         print()
 
-        choice = self._get_choice("Select an option: ", range(1, 9))
+        choice = self._get_choice("Select an option: ", range(1, 11))
 
         if choice == 1:
             self._display_schedule()
@@ -88,9 +90,13 @@ class CLI:
         elif choice == 6:
             self._team_lookup()
         elif choice == 7:
+            self._display_game_stats()
+        elif choice == 8:
+            self._display_season_leaders()
+        elif choice == 9:
             self._sim_rest_of_season()
             return 'postseason'
-        elif choice == 8:
+        elif choice == 10:
             return 'main'
 
     def _postseason_menu(self):
@@ -103,10 +109,11 @@ class CLI:
         print("  1. View Final Standings")
         print("  2. View Playoff Bracket (Top 8)")
         print("  3. Run Playoffs")
-        print("  4. Return to Main Menu")
+        print("  4. View Season Leaders")
+        print("  5. Return to Main Menu")
         print()
 
-        choice = self._get_choice("Select an option: ", range(1, 5))
+        choice = self._get_choice("Select an option: ", range(1, 6))
 
         if choice == 1:
             self._display_standings()
@@ -116,6 +123,8 @@ class CLI:
             self._run_playoffs()
             return 'champion'
         elif choice == 4:
+            self._display_season_leaders()
+        elif choice == 5:
             return 'main'
 
     def _champion_screen(self):
@@ -126,17 +135,20 @@ class CLI:
         print("=" * 50)
         print()
         print("  1. View Final Standings")
-        print("  2. New Season")
-        print("  3. Quit")
+        print("  2. View Season Leaders")
+        print("  3. New Season")
+        print("  4. Quit")
         print()
 
-        choice = self._get_choice("Select an option: ", range(1, 4))
+        choice = self._get_choice("Select an option: ", range(1, 5))
 
         if choice == 1:
             self._display_standings()
         elif choice == 2:
-            return 'new_season'
+            self._display_season_leaders()
         elif choice == 3:
+            return 'new_season'
+        elif choice == 4:
             return 'quit'
 
     # ── State loops ───────────────────────────────────────────────
@@ -276,6 +288,54 @@ class CLI:
         print(f"    (4) {top_8[3]:<20} vs  (5) {top_8[4]}")
         print(f"    (2) {top_8[1]:<20} vs  (7) {top_8[6]}")
         print(f"    (3) {top_8[2]:<20} vs  (6) {top_8[5]}")
+        self._pause()
+
+    def _display_game_stats(self):
+        """Show box scores for the last played week."""
+        prev_week = self.season.current_week - 1
+        stats_list = self.season.get_game_stats_for_week(prev_week)
+        if not stats_list:
+            print(f"\nNo game stats available for Week {prev_week}.")
+            self._pause()
+            return
+
+        print(f"\n{'─' * 60}")
+        print(f"  Week {prev_week} Games")
+        print(f"{'─' * 60}")
+        for i, gs in enumerate(stats_list, 1):
+            print(f"  {i}. {gs.home_team} {gs.home_score} - {gs.away_team} {gs.away_score}")
+
+        try:
+            pick = int(input("\nSelect a game (0 to cancel): "))
+        except (ValueError, EOFError):
+            return
+        if pick < 1 or pick > len(stats_list):
+            return
+
+        print()
+        print(stats_list[pick - 1].format_box_score())
+        self._pause()
+
+    def _display_season_leaders(self):
+        """Show top 10 season leaders for key stat categories."""
+        categories = [
+            ('passing_yards', 'Top 10 Passing Yards'),
+            ('rushing_yards', 'Top 10 Rushing Yards'),
+            ('receiving_yards', 'Top 10 Receiving Yards'),
+        ]
+
+        for stat, title in categories:
+            leaders = self.season.get_season_leaders(stat, top_n=10)
+            print(f"\n{'─' * 70}")
+            print(f"  {title}")
+            print(f"{'─' * 70}")
+            print(f"  {'Rank':<6}{'Player':<25}{'Team':<20}{'Value':>8}")
+            print(f"  {'─' * 64}")
+            if not leaders:
+                print("  No stats recorded yet.")
+            for i, entry in enumerate(leaders, 1):
+                print(f"  {i:<6}{entry['name']:<25}{entry['team']:<20}{entry['value']:>8}")
+
         self._pause()
 
     def _team_lookup(self):

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,336 @@
+"""Interactive CLI for NCAA College Football Simulation."""
+
+import os
+import sys
+
+# Ensure src/ and project root are on the path for bare imports
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_src_dir = os.path.join(_project_root, 'src')
+for _p in (_project_root, _src_dir):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from utils.team_loader import load_teams_from_json
+from season import Season
+
+
+_DATA_PATH = os.path.join(_project_root, 'utils', 'cfb.json')
+
+
+class CLI:
+    """Menu-driven CLI for the college football simulator."""
+
+    def __init__(self):
+        self.season = None
+        self.teams = None
+
+    def run(self):
+        """Main entry point — loops through menus until quit."""
+        while True:
+            action = self._main_menu()
+            if action == 'quit':
+                break
+
+    # ── Menus ──────────────────────────────────────────────────────
+
+    def _main_menu(self):
+        self._clear()
+        print("=" * 50)
+        print("   NCAA COLLEGE FOOTBALL SIMULATOR")
+        print("=" * 50)
+        print()
+        print("  1. Start New Season")
+        print("  2. Simulate Full Season (auto-play everything)")
+        print("  3. Quit")
+        print()
+
+        choice = self._get_choice("Select an option: ", range(1, 4))
+
+        if choice == 1:
+            self._start_season()
+            self._weekly_loop()
+        elif choice == 2:
+            self._start_season()
+            self._simulate_full_season()
+        else:
+            return 'quit'
+
+    def _weekly_menu(self):
+        """Returns an action string or None to keep looping."""
+        self._clear()
+        week = self.season.current_week
+        print("=" * 50)
+        print(f"   WEEK {week}")
+        print("=" * 50)
+        print()
+        print("  1. View This Week's Schedule")
+        print("  2. Play This Week")
+        print("  3. View Last Week's Results")
+        print("  4. View Standings")
+        print("  5. View Top 25")
+        print("  6. Team Lookup")
+        print("  7. Sim Rest of Regular Season")
+        print("  8. Return to Main Menu")
+        print()
+
+        choice = self._get_choice("Select an option: ", range(1, 9))
+
+        if choice == 1:
+            self._display_schedule()
+        elif choice == 2:
+            self._play_week()
+        elif choice == 3:
+            self._display_results()
+        elif choice == 4:
+            self._display_standings()
+        elif choice == 5:
+            self._display_top_25()
+        elif choice == 6:
+            self._team_lookup()
+        elif choice == 7:
+            self._sim_rest_of_season()
+            return 'postseason'
+        elif choice == 8:
+            return 'main'
+
+    def _postseason_menu(self):
+        """Returns an action string or None to keep looping."""
+        self._clear()
+        print("=" * 50)
+        print("   POST-SEASON")
+        print("=" * 50)
+        print()
+        print("  1. View Final Standings")
+        print("  2. View Playoff Bracket (Top 8)")
+        print("  3. Run Playoffs")
+        print("  4. Return to Main Menu")
+        print()
+
+        choice = self._get_choice("Select an option: ", range(1, 5))
+
+        if choice == 1:
+            self._display_standings()
+        elif choice == 2:
+            self._display_playoff_bracket()
+        elif choice == 3:
+            self._run_playoffs()
+            return 'champion'
+        elif choice == 4:
+            return 'main'
+
+    def _champion_screen(self):
+        """Returns an action string or None to keep looping."""
+        self._clear()
+        print("=" * 50)
+        print(f"   CHAMPION: {self.season.champion.name}")
+        print("=" * 50)
+        print()
+        print("  1. View Final Standings")
+        print("  2. New Season")
+        print("  3. Quit")
+        print()
+
+        choice = self._get_choice("Select an option: ", range(1, 4))
+
+        if choice == 1:
+            self._display_standings()
+        elif choice == 2:
+            return 'new_season'
+        elif choice == 3:
+            return 'quit'
+
+    # ── State loops ───────────────────────────────────────────────
+
+    def _weekly_loop(self):
+        while True:
+            if self.season.is_regular_season_complete():
+                self._postseason_loop()
+                return
+
+            action = self._weekly_menu()
+            if action == 'postseason':
+                self._postseason_loop()
+                return
+            elif action == 'main':
+                return
+
+    def _postseason_loop(self):
+        while True:
+            action = self._postseason_menu()
+            if action == 'champion':
+                self._champion_loop()
+                return
+            elif action == 'main':
+                return
+
+    def _champion_loop(self):
+        while True:
+            action = self._champion_screen()
+            if action == 'new_season':
+                self._start_season()
+                self._weekly_loop()
+                return
+            elif action == 'quit':
+                raise SystemExit(0)
+
+    # ── Actions ───────────────────────────────────────────────────
+
+    def _start_season(self):
+        print("\nLoading teams and generating schedule...")
+        self.teams = load_teams_from_json(_DATA_PATH)
+        self.season = Season(self.teams)
+        print(f"Season created with {len(self.teams)} teams.")
+        self._pause()
+
+    def _play_week(self):
+        week = self.season.current_week
+        if week not in self.season.schedule or not self.season.schedule[week]:
+            print("\nNo games scheduled this week.")
+            self._pause()
+            return
+        print(f"\nSimulating Week {week}...")
+        self.season.play_week()
+        print("Done! Games have been played.")
+        self._display_results()
+
+    def _sim_rest_of_season(self):
+        print("\nSimulating remaining regular season games...")
+        weeks_played = 0
+        while not self.season.is_regular_season_complete():
+            self.season.play_week()
+            weeks_played += 1
+        print(f"Simulated {weeks_played} week(s). Regular season complete!")
+        self._pause()
+
+    def _simulate_full_season(self):
+        print("\nSimulating entire season and playoffs...")
+        champion = self.season.simulate_full_season()
+        print(f"\nSeason complete!")
+        self._display_standings()
+        print(f"\n{'=' * 50}")
+        print(f"   CHAMPION: {champion.name}")
+        print(f"{'=' * 50}")
+        self._pause()
+
+    def _run_playoffs(self):
+        print()
+        champion = self.season.run_playoffs()
+        print()
+        self._pause()
+
+    # ── Display helpers ───────────────────────────────────────────
+
+    def _display_schedule(self):
+        week = self.season.current_week
+        games = self.season.get_schedule_for_week(week)
+        print(f"\n{'─' * 50}")
+        print(f"  Week {week} Schedule ({len(games)} games)")
+        print(f"{'─' * 50}")
+        if not games:
+            print("  No games scheduled.")
+        else:
+            for i, (home, away) in enumerate(games, 1):
+                print(f"  {i:>3}. {home} vs {away}")
+        self._pause()
+
+    def _display_results(self):
+        results = self.season.get_results()
+        prev_week = self.season.current_week - 1
+        print(f"\n{'─' * 50}")
+        print(f"  Week {prev_week} Results")
+        print(f"{'─' * 50}")
+        if not results:
+            print("  No results available.")
+        else:
+            for result in results:
+                print(f"  {result}")
+        self._pause()
+
+    def _display_standings(self):
+        standings = self.season.get_standings_sorted()
+        print(f"\n{'─' * 60}")
+        print(f"  {'Rank':<6}{'Team':<30}{'W':>4}{'L':>4}{'T':>4}")
+        print(f"{'─' * 60}")
+        for i, (team, record) in enumerate(standings, 1):
+            print(f"  {i:<6}{team:<30}{record['wins']:>4}{record['losses']:>4}{record['ties']:>4}")
+            if i == 25:
+                print(f"{'─' * 60}")
+        self._pause()
+
+    def _display_top_25(self):
+        standings = self.season.get_standings_sorted()[:25]
+        print(f"\n{'─' * 60}")
+        print(f"  {'Rank':<6}{'Team':<30}{'W':>4}{'L':>4}{'T':>4}")
+        print(f"{'─' * 60}")
+        for i, (team, record) in enumerate(standings, 1):
+            print(f"  {i:<6}{team:<30}{record['wins']:>4}{record['losses']:>4}{record['ties']:>4}")
+        self._pause()
+
+    def _display_playoff_bracket(self):
+        top_8 = self.season.get_top_teams(8)
+        print(f"\n{'─' * 50}")
+        print("  8-Team Playoff Bracket")
+        print(f"{'─' * 50}")
+        print(f"  Quarterfinals:")
+        print(f"    (1) {top_8[0]:<20} vs  (8) {top_8[7]}")
+        print(f"    (4) {top_8[3]:<20} vs  (5) {top_8[4]}")
+        print(f"    (2) {top_8[1]:<20} vs  (7) {top_8[6]}")
+        print(f"    (3) {top_8[2]:<20} vs  (6) {top_8[5]}")
+        self._pause()
+
+    def _team_lookup(self):
+        query = input("\nEnter team name (or part of name): ").strip()
+        if not query:
+            return
+
+        matches = [t for t in self.teams if query.lower() in t.name.lower()]
+        if not matches:
+            print(f"  No teams found matching '{query}'.")
+            self._pause()
+            return
+
+        for team in matches:
+            record = self.season.standings[team.name]
+            print(f"\n{'─' * 50}")
+            print(f"  {team.name} {team.nickname}")
+            print(f"  {team.city}, {team.state} | {team.conference}")
+            print(f"  Record: {record['wins']}W - {record['losses']}L - {record['ties']}T")
+            print(f"\n  Starting Lineup:")
+            starters = team.get_starters()
+            for unit_name, unit in [('Offense', 'offense'), ('Defense', 'defense'), ('Special Teams', 'special_teams')]:
+                print(f"    {unit_name}:")
+                for pos, players in starters[unit].items():
+                    for p in players:
+                        print(f"      {pos:<22} #{p.number:<4} {p.first_name} {p.last_name} ({p.rating})")
+        self._pause()
+
+    # ── Utilities ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _clear():
+        os.system('cls' if os.name == 'nt' else 'clear')
+
+    @staticmethod
+    def _get_choice(prompt, valid_range):
+        """Prompt for an integer within valid_range, repeating on bad input."""
+        while True:
+            try:
+                value = int(input(prompt))
+                if value in valid_range:
+                    return value
+            except (ValueError, EOFError):
+                pass
+            print(f"  Please enter a number between {min(valid_range)} and {max(valid_range)}.")
+
+    @staticmethod
+    def _pause():
+        input("\nPress Enter to continue...")
+
+
+def main():
+    cli = CLI()
+    cli.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/game.py
+++ b/src/game.py
@@ -1,5 +1,4 @@
 import random
-from team import Team
 from game_clock import GameClock
 from game_state import GameState
 from score import Score
@@ -8,11 +7,17 @@ from stats import GameStats
 
 class Game:
     """Manages a football game between two teams."""
-    
-    def __init__(self, home_name, away_name, playoff=False):
-        """Initialize a new game between two teams."""
-        self.home = Team(home_name)
-        self.away = Team(away_name)
+
+    def __init__(self, home, away, playoff=False):
+        """Initialize a new game between two teams.
+
+        Args:
+            home: Team object for the home team
+            away: Team object for the away team
+            playoff: Whether this is a playoff game
+        """
+        self.home = home
+        self.away = away
         self.score = Score()
         self.state = GameState()
         self.current_offense = self.home
@@ -21,7 +26,8 @@ class Game:
         self.loser = None
         self.clock = GameClock()
         self.playoff = playoff
-        self.stats = GameStats(home_name, away_name)
+        self.stats = GameStats(home.name, away.name)
+        self._last_play = None
 
     def start_game(self):
         """Start and run the entire game simulation."""
@@ -198,6 +204,7 @@ class Game:
 
         # Execute the play
         yards_gained = play.execute()
+        self._last_play = play
 
         # Handle turnover
         if play.turnover:
@@ -321,6 +328,7 @@ class Game:
         elif self.state.state == 'down' and isinstance(self.state.down, int):
             if self.state.ball_pos_raw >= 100:
                 self.score.home_score += 6
+                self._credit_touchdown()
                 self.state.ball_pos_raw = 98
                 self.state.ball_pos = 2
                 self.state.down = 'PAT'
@@ -328,6 +336,7 @@ class Game:
                 self.clock.stop()
             elif self.state.ball_pos_raw <= 0:
                 self.score.away_score += 6
+                self._credit_touchdown()
                 self.state.ball_pos_raw = 2
                 self.state.ball_pos = 2
                 self.state.down = 'PAT'
@@ -339,22 +348,48 @@ class Game:
             if self.state.ball_pos_raw >= 100:
                 if self.state.overtime_round in [1, 2]:
                     self.score.home_score += 6
+                    self._credit_touchdown()
                     self.state.state = 'pat'
                     self.state.down = 'PAT'
                 elif self.state.overtime_round >= 3:
                     self.score.home_score += 2
+                    self._credit_touchdown()
                     self.state.state = 'kickoff'
             elif self.state.ball_pos_raw <= 0:
                 if self.state.overtime_round in [1, 2]:
                     self.score.away_score += 6
+                    self._credit_touchdown()
                     self.state.state = 'pat'
                     self.state.down = 'PAT'
                 elif self.state.overtime_round >= 3:
                     self.score.away_score += 2
+                    self._credit_touchdown()
                     self.state.state = 'kickoff'
                 
         self.set_ball()
         return self
+
+    def _credit_touchdown(self):
+        """Credit a touchdown to the players involved in the last play."""
+        play = self._last_play
+        if play is None or self.stats is None:
+            return
+
+        # RunPlay has a 'carrier' attribute
+        if hasattr(play, 'carrier'):
+            player_stats = self.stats.get_player_stats(play.carrier)
+            if player_stats:
+                player_stats.rushing_tds += 1
+
+        # PassPlay has 'passer' and 'target' attributes
+        elif hasattr(play, 'passer') and hasattr(play, 'target'):
+            if play.target is not None and play.yards_gained is not None and play.yards_gained > 0:
+                passer_stats = self.stats.get_player_stats(play.passer)
+                if passer_stats:
+                    passer_stats.passing_tds += 1
+                target_stats = self.stats.get_player_stats(play.target)
+                if target_stats:
+                    target_stats.receiving_tds += 1
 
     # Team possession changes
     def turnover(self):

--- a/src/main.py
+++ b/src/main.py
@@ -21,3 +21,7 @@ def get_results():
 
 def get_top_teams(top_n=8):
     return season.get_top_teams(top_n)
+
+if __name__ == '__main__':
+    from cli import main as cli_main
+    cli_main()

--- a/src/playoffs.py
+++ b/src/playoffs.py
@@ -13,7 +13,7 @@ class Playoffs:
         ]
 
     def play_game(self, home_team, away_team):
-        game = Game(home_team.name, away_team.name, playoff=True)
+        game = Game(home_team, away_team, playoff=True)
         game.start_game()
         return game.winner
 

--- a/src/season.py
+++ b/src/season.py
@@ -2,6 +2,7 @@ import random
 from collections import defaultdict
 from game import Game
 from playoffs import Playoffs
+from stats import SeasonStats
 
 class Season:
     def __init__(self, teams):
@@ -12,6 +13,7 @@ class Season:
         self.standings = {team.name: {'wins': 0, 'losses': 0, 'ties': 0} for team in teams}
         self.matchups = set()
         self.game_stats = {}
+        self.season_stats = SeasonStats()
         self.champion = None
         self.playoff_results = []
         self.generate_schedule()
@@ -96,7 +98,7 @@ class Season:
         """
         Simulates a game between two teams and updates the standings.
         """
-        game = Game(home_team.name, away_team.name)
+        game = Game(home_team, away_team)
         game.start_game()
         if game.winner:
             self.standings[game.winner.name]['wins'] += 1
@@ -106,7 +108,11 @@ class Season:
             self.standings[away_team.name]['ties'] += 1
         result = f"{home_team.name} {game.score.home_score} - {away_team.name} {game.score.away_score}"
         self.results[self.current_week].append(result)
-        self.game_stats.setdefault(self.current_week, []).append(game.get_stats())
+        stats = game.get_stats()
+        stats.home_score = game.score.home_score
+        stats.away_score = game.score.away_score
+        self.game_stats.setdefault(self.current_week, []).append(stats)
+        self.season_stats.add_game(stats)
 
     def play_week(self):
         if self.current_week in self.schedule:
@@ -167,6 +173,14 @@ class Season:
         champion = playoffs.play_playoffs()
         self.champion = champion
         return champion
+
+    def get_game_stats_for_week(self, week):
+        """Returns list of GameStats for the given week."""
+        return self.game_stats.get(week, [])
+
+    def get_season_leaders(self, stat, top_n=10):
+        """Returns top N players for a given stat across the season."""
+        return self.season_stats.get_leaders(stat, top_n)
 
     def simulate_full_season(self):
         """Simulate entire season including playoffs."""

--- a/src/stats.py
+++ b/src/stats.py
@@ -112,9 +112,12 @@ class GameStats:
         """
         self.home_team = home_team
         self.away_team = away_team
+        self.home_score = 0
+        self.away_score = 0
         self._home_stats = {}  # player -> PlayerGameStats
         self._away_stats = {}  # player -> PlayerGameStats
         self._player_teams = {}  # player -> team_name (for lookup)
+        self._player_info = {}  # player_key -> (full_name, position, team_name)
 
     def _get_or_create_stats(self, player, team_name=None):
         """Get or create PlayerGameStats for a player.
@@ -134,6 +137,19 @@ class GameStats:
             team_name = self._player_teams[player_key]
         elif team_name:
             self._player_teams[player_key] = team_name
+
+        # Record player metadata when first seen
+        if player_key not in self._player_info:
+            resolved_team = team_name or self._player_teams.get(player_key, "Unknown")
+            number = getattr(player, 'number', '')
+            name = f"{player.first_name} {player.last_name}"
+            if number != '':
+                name = f"#{number} {player.first_name} {player.last_name}"
+            self._player_info[player_key] = (
+                name,
+                player.position,
+                resolved_team
+            )
 
         # Get the appropriate stats dictionary
         if team_name == self.home_team:
@@ -284,3 +300,121 @@ class GameStats:
             totals['def_tds'] += player_stats.def_tds
 
         return totals
+
+    def get_player_statlines(self):
+        """Return list of dicts with player info + stats for all players in this game."""
+        statlines = []
+        for player_key, pgs in {**self._home_stats, **self._away_stats}.items():
+            name, position, team = self._player_info.get(
+                player_key, ("Unknown", "Unknown", "Unknown")
+            )
+            statlines.append({
+                'name': name, 'position': position, 'team': team, 'stats': pgs
+            })
+        return statlines
+
+    def format_box_score(self):
+        """Return a formatted box score string."""
+        lines = []
+        lines.append("=" * 60)
+        lines.append("BOX SCORE")
+        lines.append("=" * 60)
+        lines.append(
+            f"{self.home_team}: {self.home_score}  -  "
+            f"{self.away_team}: {self.away_score}"
+        )
+        lines.append("-" * 60)
+
+        for team_name, stats_dict in [
+            (self.home_team, self._home_stats),
+            (self.away_team, self._away_stats),
+        ]:
+            totals = self.get_team_totals(team_name)
+            lines.append(f"\n{team_name} Team Totals:")
+            if totals:
+                lines.append(
+                    f"  Passing: {totals['completions']}/{totals['pass_attempts']} "
+                    f"for {totals['passing_yards']} yards, "
+                    f"{totals['passing_tds']} TD, {totals['ints']} INT"
+                )
+                lines.append(
+                    f"  Rushing: {totals['rush_attempts']} carries "
+                    f"for {totals['rushing_yards']} yards, "
+                    f"{totals['rushing_tds']} TD"
+                )
+                lines.append(
+                    f"  Turnovers: {totals['fumbles'] + totals['ints']}"
+                )
+
+            # Individual player lines
+            for player_key, pgs in stats_dict.items():
+                name, position, _ = self._player_info.get(
+                    player_key, ("Unknown", "Unknown", team_name)
+                )
+                parts = []
+                if pgs.pass_attempts > 0:
+                    parts.append(
+                        f"{pgs.completions}/{pgs.pass_attempts} "
+                        f"{pgs.passing_yards} pass yds, "
+                        f"{pgs.passing_tds} TD, {pgs.ints} INT"
+                    )
+                if pgs.rush_attempts > 0:
+                    parts.append(
+                        f"{pgs.rush_attempts} car, "
+                        f"{pgs.rushing_yards} rush yds, "
+                        f"{pgs.rushing_tds} TD"
+                    )
+                if pgs.receptions > 0:
+                    parts.append(
+                        f"{pgs.receptions} rec, "
+                        f"{pgs.receiving_yards} rec yds, "
+                        f"{pgs.receiving_tds} TD"
+                    )
+                if parts:
+                    lines.append(f"    {name} ({position}): {' | '.join(parts)}")
+
+        lines.append("\n" + "=" * 60)
+        return "\n".join(lines)
+
+
+class SeasonStats:
+    """Aggregates player statistics across an entire season."""
+
+    def __init__(self):
+        self._stats = {}  # (team, name, position) -> PlayerGameStats (cumulative)
+        self._player_info = {}  # (team, name, position) -> (name, position, team)
+
+    def add_game(self, game_stats):
+        """Merge a GameStats into season totals."""
+        for statline in game_stats.get_player_statlines():
+            key = (statline['team'], statline['name'], statline['position'])
+            if key not in self._stats:
+                self._stats[key] = PlayerGameStats()
+                self._player_info[key] = (
+                    statline['name'], statline['position'], statline['team']
+                )
+            self._accumulate(self._stats[key], statline['stats'])
+
+    def _accumulate(self, target, source):
+        """Add all numeric stat fields from source into target."""
+        for attr in vars(source):
+            val = getattr(source, attr)
+            if isinstance(val, (int, float)):
+                setattr(target, attr, getattr(target, attr) + val)
+
+    def get_leaders(self, stat, top_n=10):
+        """Top N players for a given stat, sorted descending."""
+        entries = []
+        for key, pgs in self._stats.items():
+            value = getattr(pgs, stat, 0)
+            if value > 0:
+                name, position, team = self._player_info[key]
+                entries.append({
+                    'name': name,
+                    'position': position,
+                    'team': team,
+                    'stats': pgs,
+                    'value': value,
+                })
+        entries.sort(key=lambda e: e['value'], reverse=True)
+        return entries[:top_n]

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -18,8 +18,8 @@ class TestGame(unittest.TestCase):
         random.seed(42)
         np.random.seed(42)
 
-        # Create a test game
-        self.game = Game("Home Team", "Away Team")
+        # Create a test game with Team objects
+        self.game = Game(Team("Home Team"), Team("Away Team"))
 
         # Mock player retrieval instead of trying to add players
         # This lets us test without modifying the actual Team class

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,5 +1,5 @@
 import test_setup
-from src.stats import PlayerGameStats, GameStats
+from src.stats import PlayerGameStats, GameStats, SeasonStats
 from player import Player
 import unittest
 
@@ -215,6 +215,8 @@ class TestGameStats(unittest.TestCase):
         self.home_qb = Player("Tom", "Brady", "Quarterback", 99, 12, side="offense")
         self.home_rb = Player("Derrick", "Henry", "Running Back", 95, 22, side="offense")
         self.home_wr = Player("Justin", "Jefferson", "Wide Receiver", 97, 18, side="offense")
+
+        self.home_wr2 = Player("Ja'Marr", "Chase", "Wide Receiver", 96, 1, side="offense")
 
         self.away_qb = Player("Patrick", "Mahomes", "Quarterback", 99, 15, side="offense")
         self.away_lb = Player("Micah", "Parsons", "Linebacker", 98, 11, side="defense")
@@ -461,6 +463,173 @@ class TestGameStats(unittest.TestCase):
 
         self.assertEqual(home_totals['passing_yards'], 30)
         self.assertEqual(away_totals['passing_yards'], 20)
+
+    def test_qb_passes_to_two_different_receivers(self):
+        """Test that a QB passing to two different WRs tracks each receiver's stats separately."""
+        # QB completes two passes to WR1
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr,
+            completed=True, yards=20, team_name="Home Tigers"
+        )
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr,
+            completed=True, yards=35, td=True, team_name="Home Tigers"
+        )
+
+        # QB completes three passes to WR2
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr2,
+            completed=True, yards=10, team_name="Home Tigers"
+        )
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr2,
+            completed=True, yards=15, team_name="Home Tigers"
+        )
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr2,
+            completed=True, yards=50, td=True, team_name="Home Tigers"
+        )
+
+        # QB should have aggregate totals
+        qb_stats = self.game_stats.get_player_stats(self.home_qb)
+        self.assertEqual(qb_stats.pass_attempts, 5)
+        self.assertEqual(qb_stats.completions, 5)
+        self.assertEqual(qb_stats.passing_yards, 130)
+        self.assertEqual(qb_stats.passing_tds, 2)
+
+        # WR1 (Jefferson) — 2 catches, 55 yards, 1 TD
+        wr1_stats = self.game_stats.get_player_stats(self.home_wr)
+        self.assertEqual(wr1_stats.receptions, 2)
+        self.assertEqual(wr1_stats.receiving_yards, 55)
+        self.assertEqual(wr1_stats.receiving_tds, 1)
+
+        # WR2 (Chase) — 3 catches, 75 yards, 1 TD
+        wr2_stats = self.game_stats.get_player_stats(self.home_wr2)
+        self.assertEqual(wr2_stats.receptions, 3)
+        self.assertEqual(wr2_stats.receiving_yards, 75)
+        self.assertEqual(wr2_stats.receiving_tds, 1)
+
+        # Both receivers should appear as distinct entries in player statlines
+        statlines = self.game_stats.get_player_statlines()
+        receiver_lines = [s for s in statlines if s['position'] == 'Wide Receiver']
+        self.assertEqual(len(receiver_lines), 2)
+        receiver_names = {s['name'] for s in receiver_lines}
+        self.assertEqual(receiver_names, {"#18 Justin Jefferson", "#1 Ja'Marr Chase"})
+
+
+class TestGameStatsPlayerInfo(unittest.TestCase):
+    """Tests for player metadata tracking in GameStats."""
+
+    def setUp(self):
+        self.game_stats = GameStats("Home Tigers", "Away Lions")
+        self.home_qb = Player("Tom", "Brady", "Quarterback", 99, 12, side="offense")
+        self.home_wr = Player("Justin", "Jefferson", "Wide Receiver", 97, 18, side="offense")
+        self.away_qb = Player("Patrick", "Mahomes", "Quarterback", 99, 15, side="offense")
+
+    def test_player_info_populated_on_record(self):
+        """_player_info is populated when stats are recorded."""
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr,
+            completed=True, yards=20, team_name="Home Tigers"
+        )
+        qb_key = id(self.home_qb)
+        self.assertIn(qb_key, self.game_stats._player_info)
+        name, pos, team = self.game_stats._player_info[qb_key]
+        self.assertEqual(name, "#12 Tom Brady")
+        self.assertEqual(pos, "Quarterback")
+        self.assertEqual(team, "Home Tigers")
+
+    def test_get_player_statlines_returns_metadata(self):
+        """get_player_statlines() returns correct metadata + stats."""
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr,
+            completed=True, yards=25, team_name="Home Tigers"
+        )
+        self.game_stats.record_rush(
+            carrier=self.away_qb, yards=10, team_name="Away Lions"
+        )
+
+        statlines = self.game_stats.get_player_statlines()
+        names = [s['name'] for s in statlines]
+        self.assertIn("#12 Tom Brady", names)
+        self.assertIn("#18 Justin Jefferson", names)
+        self.assertIn("#15 Patrick Mahomes", names)
+
+        qb_line = [s for s in statlines if s['name'] == "#12 Tom Brady"][0]
+        self.assertEqual(qb_line['team'], "Home Tigers")
+        self.assertEqual(qb_line['position'], "Quarterback")
+        self.assertEqual(qb_line['stats'].passing_yards, 25)
+
+    def test_format_box_score(self):
+        """format_box_score() returns a non-empty string with team names."""
+        self.game_stats.home_score = 21
+        self.game_stats.away_score = 14
+        self.game_stats.record_pass(
+            passer=self.home_qb, target=self.home_wr,
+            completed=True, yards=30, td=True, team_name="Home Tigers"
+        )
+        box = self.game_stats.format_box_score()
+        self.assertIn("Home Tigers", box)
+        self.assertIn("Away Lions", box)
+        self.assertIn("21", box)
+        self.assertIn("14", box)
+
+
+class TestSeasonStats(unittest.TestCase):
+    """Tests for SeasonStats class."""
+
+    def setUp(self):
+        self.season_stats = SeasonStats()
+        self.qb = Player("Tom", "Brady", "Quarterback", 99, 12, side="offense")
+        self.wr = Player("Justin", "Jefferson", "Wide Receiver", 97, 18, side="offense")
+        self.rb = Player("Derrick", "Henry", "Running Back", 95, 22, side="offense")
+
+    def _make_game_stats(self, team_name="Tigers"):
+        """Helper to create a GameStats with some recorded plays."""
+        gs = GameStats(team_name, "Opponent")
+        return gs
+
+    def test_add_game_accumulates(self):
+        """add_game() accumulates stats from multiple games."""
+        gs1 = self._make_game_stats()
+        gs1.record_pass(self.qb, self.wr, completed=True, yards=100, team_name="Tigers")
+        self.season_stats.add_game(gs1)
+
+        gs2 = self._make_game_stats()
+        gs2.record_pass(self.qb, self.wr, completed=True, yards=150, team_name="Tigers")
+        self.season_stats.add_game(gs2)
+
+        leaders = self.season_stats.get_leaders('passing_yards')
+        qb_entry = [e for e in leaders if e['name'] == "#12 Tom Brady"]
+        self.assertEqual(len(qb_entry), 1)
+        self.assertEqual(qb_entry[0]['value'], 250)
+
+    def test_get_leaders_sorted(self):
+        """get_leaders() returns sorted results."""
+        gs = self._make_game_stats()
+        gs.record_pass(self.qb, self.wr, completed=True, yards=200, team_name="Tigers")
+        gs.record_rush(self.rb, yards=300, team_name="Tigers")
+        self.season_stats.add_game(gs)
+
+        rushing_leaders = self.season_stats.get_leaders('rushing_yards')
+        self.assertEqual(rushing_leaders[0]['name'], "#22 Derrick Henry")
+        self.assertEqual(rushing_leaders[0]['value'], 300)
+
+    def test_get_leaders_respects_top_n(self):
+        """get_leaders() respects top_n parameter."""
+        gs = self._make_game_stats()
+        gs.record_pass(self.qb, self.wr, completed=True, yards=100, team_name="Tigers")
+        gs.record_rush(self.rb, yards=50, team_name="Tigers")
+        self.season_stats.add_game(gs)
+
+        # Only ask for 1 leader
+        leaders = self.season_stats.get_leaders('receiving_yards', top_n=1)
+        self.assertLessEqual(len(leaders), 1)
+
+    def test_empty_season_returns_empty_leaders(self):
+        """Empty season returns empty leaders list."""
+        leaders = self.season_stats.get_leaders('passing_yards')
+        self.assertEqual(leaders, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Fix player identity bug**: `Game.__init__` now accepts `Team` objects instead of name strings, so player stats persist across a season instead of being lost after each game.
- **Add TD/INT tracking**: Touchdowns are now retroactively credited to the correct players (passing/rushing/receiving TDs) after `points()` detects scoring from ball position. INTs were already tracked correctly.
- **Add `SeasonStats` class**: Accumulates player stats across all games in a season, with `get_leaders(stat, top_n)` for leaderboard queries.
- **Add CLI stat menus**: Weekly menu gains "View Game Box Scores" and "View Season Leaders" options; postseason and champion screens also get season leaders. Box scores show per-player lines with jersey numbers.
- **New tests**: `TestGameStatsPlayerInfo` (3 tests), `TestSeasonStats` (4 tests), and a multi-receiver tracking test validating independent stat lines when a QB throws to two different WRs.

## Test plan
- [x] `python3.10 -m pytest tests/ -v` — all 89 tests pass
- [ ] Manual: play a week via CLI → view box scores → confirm TDs show on player lines
- [ ] Manual: sim multiple weeks → view season leaders → confirm accumulation across weeks
- [ ] Manual: run through postseason and champion screens → confirm season leaders option works

🤖 Generated with [Claude Code](https://claude.com/claude-code)